### PR TITLE
T201946 fix p newlines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,13 @@
 		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"jakub-onderka/php-console-highlighter": "0.3.2",
 		"mediawiki/mediawiki-codesniffer": "24.0.0",
-		"mediawiki/minus-x": "0.3.1"
+		"mediawiki/minus-x": "0.3.1",
+		"phpunit/phpunit": "^8"
+	},
+	"autoload": {
+		"classmap": [
+			"includes/"
+		]
 	},
 	"scripts": {
 		"fix": [
@@ -13,10 +19,14 @@
 		"test": [
 			"parallel-lint . --exclude vendor --exclude node_modules",
 			"phpcs -p -s",
-			"minus-x check ."
+			"minus-x check .",
+			"./vendor/bin/phpunit --bootstrap vendor/autoload.php tests/phpunit/ExtractFormatterTest.php"
 		]
 	},
 	"extra": {
 		"phan-taint-check-plugin": "1.5.0"
+	},
+	"require": {
+		"wikimedia/html-formatter": "^1.0"
 	}
 }

--- a/includes/ExtractFormatter.php
+++ b/includes/ExtractFormatter.php
@@ -75,6 +75,9 @@ class ExtractFormatter extends HtmlFormatter {
 	 */
 	public function onHtmlReady( $html ) {
 		if ( $this->plainText ) {
+			// Add newlines between paragraph tags that don't have at least one or else
+			// there won't be any whitespace preserved. See issue T20194.
+			$html = preg_replace( '/(<\/p>)\V*<p>/iU', '$1' . "\n\n", $html );
 			$html = preg_replace( '/\s*(<h([1-6])\b)/i',
 				"\n\n" . self::SECTION_MARKER_START . '$2' . self::SECTION_MARKER_END . '$1',
 				$html

--- a/tests/phpunit/ExtractFormatterTest.php
+++ b/tests/phpunit/ExtractFormatterTest.php
@@ -2,7 +2,7 @@
 
 namespace TextExtracts\Test;
 
-use MediaWikiTestCase;
+use PHPUnit\Framework\TestCase as MediaWikiTestCase;
 use TextExtracts\ExtractFormatter;
 
 /**
@@ -22,11 +22,12 @@ class ExtractFormatterTest extends MediaWikiTestCase {
 	}
 
 	public function provideExtracts() {
-		// phpcs:ignore Generic.Files.LineLength
+		// phpcs:disable Generic.Files.LineLength
 		$dutch = '<b>Dutch</b> (<span class="unicode haudio" style="white-space:nowrap;"><span class="fn"><a href="/wiki/File:Nl-Nederlands.ogg" title="About this sound"><img alt="About this sound" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Loudspeaker.svg/11px-Loudspeaker.svg.png" width="11" height="11" srcset="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Loudspeaker.svg/17px-Loudspeaker.svg.png 1.5x, https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Loudspeaker.svg/22px-Loudspeaker.svg.png 2x" /></a>&#160;<a href="https://upload.wikimedia.org/wikipedia/commons/d/db/Nl-Nederlands.ogg" class="internal" title="Nl-Nederlands.ogg"><i>Nederlands</i></a></span>&#160;<small class="metadata audiolinkinfo" style="cursor:help;">(<a href="/w/index.php?title=Wikipedia:Media_help&amp;action=edit&amp;redlink=1" class="new" title="Wikipedia:Media help (page does not exist)"><span style="cursor:help;">help</span></a>·<a href="/wiki/File:Nl-Nederlands.ogg" title="File:Nl-Nederlands.ogg"><span style="cursor:help;">info</span></a>)</small></span>) is a <a href="/w/index.php?title=West_Germanic_languages&amp;action=edit&amp;redlink=1" class="new" title="West Germanic languages (page does not exist)">West Germanic language</a> and the native language of most of the population of the <a href="/w/index.php?title=Netherlands&amp;action=edit&amp;redlink=1" class="new" title="Netherlands (page does not exist)">Netherlands</a>';
 		$tocText = 'Lead<div id="toc" class="toc">TOC goes here</div>
 <h1>Section</h1>
 <p>Section text</p>';
+		// phpcs:enable Generic.Files.LineLength
 
 		return [
 			[
@@ -74,6 +75,13 @@ class ExtractFormatterTest extends MediaWikiTestCase {
 				$tocText,
 				true,
 			],
+			[
+				// Verify that paragraph endings work properly.
+				"Paragraph 1\n\nParagraph 2\n\nParagraph 3",
+				"<p>Paragraph 1</p><p>Paragraph 2</p> <p>Paragraph 3</p>",
+				true,
+			],
+
 		];
 	}
 


### PR DESCRIPTION
This seems to identify and resolve the issue in https://phabricator.wikimedia.org/T201946.

Basically, the HTMLFormatter from `wikimedia/html-formatter` strips out all the tags and if there isn't any whitespace (spaces, newlines, etc) already present in the markup, then the `$this->flattenAllTags()` call will not make them. This could be solved in whatever generates the initial markup too, but at least this seems to work.

Note:
* This is the first time digging into mediawiki, so be warned.
* The first commit adds dependencies to composer so that I could run the tests, feedback welcome if that's not the right way to approach that.
* `MediaWikiTestCase` was not available, so I swapped to using `PHPUnit\Framework\TestCase` and it seems to work fine.
